### PR TITLE
fix : 필터 내 예외처리 AuthenticationEntryPoint에서 일괄 처리하는 도중 에러

### DIFF
--- a/src/main/java/com/soeun/GiftFunding/config/SecurityConfig.java
+++ b/src/main/java/com/soeun/GiftFunding/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.soeun.GiftFunding.config;
 
+import com.soeun.GiftFunding.exception.CustomAccessDeniedHandler;
+import com.soeun.GiftFunding.exception.CustomAuthenticationEntryPoint;
 import com.soeun.GiftFunding.security.JwtAuthenticationFilter;
 import com.soeun.GiftFunding.security.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtExceptionFilter jwtExceptionFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
@@ -32,6 +35,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .permitAll()
             .antMatchers("/oauth/kakao", "/kakao")
             .permitAll()
+
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint(authenticationEntryPoint)
+            .accessDeniedHandler(accessDeniedHandler)
 
             .and()
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/soeun/GiftFunding/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/soeun/GiftFunding/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.soeun.GiftFunding.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soeun.GiftFunding.dto.ErrorResponse;
+import com.soeun.GiftFunding.type.ErrorType;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.info("인가 실패");
+
+        sendErrorResponse(response, "인증 실패");
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
+        TokenException e = new TokenException(ErrorType.INVALID_TOKEN);
+        log.info("CustomAccessDenied");
+        response.setStatus(HttpStatus.BAD_REQUEST.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(e.getErrorCode().getDescription()));
+    }
+}

--- a/src/main/java/com/soeun/GiftFunding/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/soeun/GiftFunding/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,49 @@
+package com.soeun.GiftFunding.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.soeun.GiftFunding.dto.ErrorResponse;
+import com.soeun.GiftFunding.type.ErrorType;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        Object exception = request.getAttribute("exception");
+        log.info("인증 실패");
+        if (exception instanceof ErrorType) {
+            ErrorType errorType = (ErrorType) exception;
+            sendResponse(response, errorType);
+
+            return;
+        }
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+
+    private void sendResponse(HttpServletResponse response, ErrorType e)
+        throws IOException {
+        response.setStatus(e.getCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String json = objectMapper.writeValueAsString(
+            ErrorResponse.of(e, e.getDescription(), e.getCode()));
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/com/soeun/GiftFunding/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soeun/GiftFunding/security/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.soeun.GiftFunding.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soeun.GiftFunding.dto.ErrorResponse;
+import com.soeun.GiftFunding.exception.TokenException;
 import com.soeun.GiftFunding.type.ErrorType;
 import java.io.IOException;
 import javax.servlet.FilterChain;
@@ -35,17 +36,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
 
         String token = this.resolveTokenFromRequest(request);
+        try {
+            if (StringUtils.hasText(token) &&
+                this.tokenProvider.validateToken(token)) {
+                Authentication auth = getAuthentication.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(auth);
 
-        if (StringUtils.hasText(token) &&
-            this.tokenProvider.validateToken(token)) {
-            Authentication auth = getAuthentication.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(auth);
-
-            log.info("[{}] -> {}"
-                , this.tokenProvider.getMail(token)
-                , request.getRequestURI());
+                log.info("[{}] -> {}"
+                    , this.tokenProvider.getMail(token)
+                    , request.getRequestURI());
+            }
+        } catch (TokenException e) {
+            request.setAttribute("exception", e.getErrorCode());
         }
-
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/soeun/GiftFunding/security/JwtExceptionFilter.java
+++ b/src/main/java/com/soeun/GiftFunding/security/JwtExceptionFilter.java
@@ -3,17 +3,20 @@ package com.soeun.GiftFunding.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soeun.GiftFunding.dto.ErrorResponse;
 import com.soeun.GiftFunding.exception.TokenException;
+import com.soeun.GiftFunding.type.ErrorType;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
+@Slf4j
 public class JwtExceptionFilter extends OncePerRequestFilter {
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
@@ -22,12 +25,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
 
         } catch (TokenException e){
-            response.setStatus(e.getErrorCode().getCode());
-            response.setContentType("application/json");
-            response.setCharacterEncoding("UTF-8");
-            String json = new ObjectMapper().writeValueAsString(
-                ErrorResponse.of(e.getErrorCode(), e.getErrorMessage(), e.getErrorCode().getCode()));
-            response.getWriter().write(json);
+            log.info("로그 던지기");
+            request.setAttribute("exception", ErrorType.INVALID_TOKEN);
         }
     }
 }

--- a/src/main/java/com/soeun/GiftFunding/security/TokenProvider.java
+++ b/src/main/java/com/soeun/GiftFunding/security/TokenProvider.java
@@ -78,6 +78,7 @@ public class TokenProvider {
         log.info(String.valueOf(claims.getExpiration()));
 
         if (claims.getExpiration().before(new Date())) {
+            log.info("토큰 만료 예외 발생");
             throw new TokenException(ErrorType.TOKEN_EXPIRED);
         }
         return true;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
**AuthenticationEntryPoint 관련 질문입니다 !**
기존 JwtAuthenticationFilter에서 TokenProvider클래스의 validateToken을 활용하여 토큰의 유효성을 검증하는데 
validationToken() 메소드에서 토큰이 만료되었다면 TokenException 예외를 던지도록 하였습니다.
호출한 AuthenticationFilter 쪽으로 예외가 넘어오게 되어 필터 내 예외를 처리할 수 있는 JwtExceptionFilter를 구현하여 에러 응답을 보내는 것 까지 완료했습니다.

여기에 덧붙여 AuthenticationEntryPoint를 활용하여 발생하는 필터 내 발생하는 예외들을 일괄처리 하고자 코드를 작성해봤는데  
JwtExceptionFilter에서도, CustomAuthenticationEntryPoint에서도 예외 응답을 보내주지 않습니다. 
제가 무엇을 놓치고 있는 걸까요 ?

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 